### PR TITLE
Open the content userInfo url

### DIFF
--- a/NotificationDemo/AppDelegate.swift
+++ b/NotificationDemo/AppDelegate.swift
@@ -75,5 +75,9 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         print("actionIdentifier \(response.actionIdentifier)")
         
         completionHandler()
+        
+        guard let linkString: String = content.userInfo["link"] as? String else { return }
+        guard let requestUrl = URL(string: linkString) else { return }
+        UIApplication.shared.open(requestUrl, options: [:], completionHandler: nil)
     }
 }


### PR DESCRIPTION
Add some syntax into the didReceivewithCompletionHandler method  for improved a symptom of can't open url from the userInfo property of UNMutableNotificationContent

`guard let linkString: String = content.userInfo["link"] as? String else { return }`
`guard let requestUrl = URL(string: linkString) else { return }`
`UIApplication.shared.open(requestUrl, options: [:], completionHandler: nil)`